### PR TITLE
fix python2 to 3

### DIFF
--- a/docker/stip/Dockerfile
+++ b/docker/stip/Dockerfile
@@ -5,10 +5,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # apt install
 ## for docker image
 RUN apt update && apt install -y \
-    git python2.7 sudo dialog systemd
+    git python3.6 sudo dialog systemd
 ## for stip-rs & stip-sns
 RUN apt install -y \
-    python-pip apache2 libapache2-mod-wsgi libmysqlclient-dev mysql-client-5.7 python3-dev libpq-dev libssl-dev \
+    python3-pip apache2 libapache2-mod-wsgi-py3 libmysqlclient-dev mysql-client-5.7 python3-dev libpq-dev libssl-dev \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 && echo "deb http://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
@@ -26,7 +26,7 @@ ENV SCRIPTS_DIR ${COMMON_DIR}/install_scripts
 # pip install
 WORKDIR /
 RUN git clone https://github.com/s-tip/stip-common.git
-RUN pip install -r ${SCRIPTS_DIR}/requirements_rs.txt -r ${SCRIPTS_DIR}/requirements_gv.txt -r ${SCRIPTS_DIR}/requirements_sns.txt
+RUN pip3 install -r ${SCRIPTS_DIR}/requirements_rs.txt -r ${SCRIPTS_DIR}/requirements_gv.txt -r ${SCRIPTS_DIR}/requirements_sns.txt
 
 # stip-common setup
 RUN mkdir -p ${INSTALL_DIR}/common
@@ -36,7 +36,7 @@ RUN ln -s ${COMMON_DIR}/src ${INSTALL_DIR}/common/src && ln -s ${COMMON_DIR}/img
 WORKDIR /stip-common
 RUN git clone https://github.com/oasis-open/cti-pattern-matcher.git
 WORKDIR /stip-common/cti-pattern-matcher/
-RUN python setup.py install
+RUN python3 setup.py install
 WORKDIR /stip-common
 RUN git clone https://github.com/s-tip/stip-rs.git
 RUN mkdir -p ${INSTALL_DIR}/rs/bin ${INSTALL_DIR}/rs/community ${INSTALL_DIR}/rs/data ${INSTALL_DIR}/rs/staticfiles

--- a/install_scripts/requirements_gv.txt
+++ b/install_scripts/requirements_gv.txt
@@ -1,6 +1,6 @@
 psycopg2-binary
 xmltodict
 pbr
-pdfminer==20140328
+pdfminer
 pymongo==2.8
 Unipath

--- a/install_scripts/requirements_rs.txt
+++ b/install_scripts/requirements_rs.txt
@@ -9,7 +9,7 @@ stix2-elevator
 stix2-validator==2.0.0.dev1
 stix2==1.1.3
 libtaxii
-MySQL-python
+mysqlclient
 stix2-patterns==1.1.0
 stix2-slider
 python-decouple
@@ -18,5 +18,5 @@ bleach
 pymisp
 Unipath
 slackclient
-maec==4.1.0.13
+maec
 misp_stix_converter

--- a/install_scripts/requirements_rs.txt
+++ b/install_scripts/requirements_rs.txt
@@ -5,7 +5,7 @@ apscheduler
 requests
 IPy
 stix
-stix2-elevator
+stix2-elevator==2.0.1
 stix2-validator==2.0.0.dev1
 stix2==1.1.3
 libtaxii

--- a/setup_gv.sh
+++ b/setup_gv.sh
@@ -9,7 +9,7 @@ git clone https://github.com/s-tip/stip-gv.git
 chown -R stip:stip stip-gv
 
 ## pip install
-pip install -r $SCRIPTS_DIR/requirements_gv.txt
+pip3 install -r $SCRIPTS_DIR/requirements_gv.txt
 
 ## copy GV setting
 mkdir -p $INSTALL_DIR/gv/bin

--- a/setup_rs.sh
+++ b/setup_rs.sh
@@ -9,12 +9,12 @@ git clone https://github.com/s-tip/stip-rs.git
 chown -R stip:stip stip-rs
 
 ## apt install
-apt install -y python-pip
-apt install -y apache2 libapache2-mod-wsgi
+apt install -y python3-pip
+apt install -y apache2 libapache2-mod-wsgi-py3
 apt install -y mysql-server libmysqlclient-dev libssl-dev
 
 ## pip install
-pip install -r $SCRIPTS_DIR/requirements_rs.txt
+pip3 install -r $SCRIPTS_DIR/requirements_rs.txt
 
 # install cti-pattern-matcher from github
 git clone https://github.com/oasis-open/cti-pattern-matcher.git

--- a/setup_rs.sh
+++ b/setup_rs.sh
@@ -19,7 +19,7 @@ pip3 install -r $SCRIPTS_DIR/requirements_rs.txt
 # install cti-pattern-matcher from github
 git clone https://github.com/oasis-open/cti-pattern-matcher.git
 cd cti-pattern-matcher/
-python setup.py install
+python3 setup.py install
 cd -
 chown -R stip:stip cti-pattern-matcher
 

--- a/setup_sns.sh
+++ b/setup_sns.sh
@@ -13,7 +13,7 @@ apt install -y python3-dev
 apt install -y libpq-dev
 
 ## pip install
-pip install -r $SCRIPTS_DIR/requirements_sns.txt
+pip3 install -r $SCRIPTS_DIR/requirements_sns.txt
 
 # copy SNS setting
 mkdir -p $INSTALL_DIR/sns/bin

--- a/setup_txs.sh
+++ b/setup_txs.sh
@@ -12,8 +12,8 @@ chown -R stip:stip stip-txs
 apt install -y supervisor gunicorn
 
 ## pip install
-pip install libtaxii
-pip install opentaxii==0.1.7
+pip3 install libtaxii
+pip3 install opentaxii==0.1.7
 
 # copy TXS setting
 mkdir -p $INSTALL_DIR/txs

--- a/src/stip/common/boot.py
+++ b/src/stip/common/boot.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 import os
 
 def is_skip_sequence():
     is_skip_sequnece = False
-    if os.environ.has_key('SKIP_BOOT_SEQUENCE') == True:
+    if ('SKIP_BOOT_SEQUENCE' in os.environ) == True:
         if os.environ['SKIP_BOOT_SEQUENCE'] == 'True':
             is_skip_sequnece = True
     return is_skip_sequnece

--- a/src/stip/common/boot.py
+++ b/src/stip/common/boot.py
@@ -1,8 +1,9 @@
 import os
 
+
 def is_skip_sequence():
     is_skip_sequnece = False
-    if ('SKIP_BOOT_SEQUENCE' in os.environ) == True:
+    if ('SKIP_BOOT_SEQUENCE' in os.environ):
         if os.environ['SKIP_BOOT_SEQUENCE'] == 'True':
             is_skip_sequnece = True
     return is_skip_sequnece

--- a/src/stip/common/const.py
+++ b/src/stip/common/const.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 from django.utils.translation import ugettext_lazy
 

--- a/src/stip/common/const.py
+++ b/src/stip/common/const.py
@@ -1,12 +1,12 @@
 import os
 from django.utils.translation import ugettext_lazy
 
-#SNS feeds.feed_stix より
-#Statement Attachement の prefix
+# SNS feeds.feed_stix より
+# Statement Attachement の prefix
 MARKING_STRUCTURE_STIP_ATTACHEMENT_CONTENT_PREFIX = 'S-TIP attachement content'
 MARKING_STRUCTURE_STIP_ATTACHEMENT_FILENAME_PREFIX = 'S-TIP attachement filename'
 
-#SNS feeds.feed_stix_common より
+# SNS feeds.feed_stix_common より
 STIP_SNS_USER_NAME_KEY = 'User Name'
 STIP_SNS_SCREEN_NAME_KEY = 'Screen Name'
 STIP_SNS_AFFILIATION_KEY = 'Affiliation'
@@ -15,9 +15,9 @@ STIP_SNS_CI_KEY = 'Critical Infrastructure'
 STIP_SNS_REFERRED_URL_KEY = 'Referred URL'
 STIP_SNS_STIX2_PACKAGE_ID_KEY = 'STIX2 Package ID'
 
-#SNS setteings より
-SNS_PROJECT_DIR='/opt/s-tip/sns'
-MEDIA_ROOT= SNS_PROJECT_DIR + os.sep + 'media'
+# SNS setteings より
+SNS_PROJECT_DIR = '/opt/s-tip/sns'
+MEDIA_ROOT = SNS_PROJECT_DIR + os.sep + 'media'
 MEDIA_URL = '/media/'
 ATTACH_FILE_DIR = MEDIA_ROOT + os.sep + 'attach' + os.sep
 STIX_FILE_DIR = MEDIA_ROOT + os.sep + 'stix' + os.sep
@@ -33,7 +33,7 @@ SNS_GV_CONCIERGE_ACCOUNT = 'gv_concierge'
 SNS_FALCON_CONCIERGE_ACCOUNT = 'falcon_concierge'
 SNS_SLACK_BOT_ACCOUNT = 'slack'
 
-#SNS から移植
+# SNS から移植
 LANGUAGES = (
     ('en', ugettext_lazy('English')),
     ('pt-br', ugettext_lazy('Portuguese')),
@@ -42,59 +42,59 @@ LANGUAGES = (
     ('fr', ugettext_lazy('French')),
     ('zh-cn', ugettext_lazy('Chinese')),
 )
-#TLPフィールドを追加
+# TLPフィールドを追加
 TLP_CHOICES = (
-    ('RED','RED'),
-    ('AMBER','AMBER'),
-    ('GREEN','GREEN'),
-    ('WHITE','WHITE'),
+    ('RED', 'RED'),
+    ('AMBER', 'AMBER'),
+    ('GREEN', 'GREEN'),
+    ('WHITE', 'WHITE'),
 )
 
-#ROLEフィールドを追加
+# ROLEフィールドを追加
 ROLE_CHOICES = (
-    ('admin',               ugettext_lazy('ROLE_CHOICE_admin')),
-    ('user',                ugettext_lazy('ROLE_CHOICE_user')),
-    ('machine',             ugettext_lazy('ROLE_CHOICE_machine')),
-    ('machine_feed_only',   ugettext_lazy('ROLE_CHOICE_machine_feed_only')),
-    ('machine_bot',         ugettext_lazy('ROLE_CHOICE_machine_bot')),
+    ('admin', ugettext_lazy('ROLE_CHOICE_admin')),
+    ('user', ugettext_lazy('ROLE_CHOICE_user')),
+    ('machine', ugettext_lazy('ROLE_CHOICE_machine')),
+    ('machine_feed_only', ugettext_lazy('ROLE_CHOICE_machine_feed_only')),
+    ('machine_bot', ugettext_lazy('ROLE_CHOICE_machine_bot')),
 )
 
-SECTOR_GROUP_CHOICES=  (
-    ('chemical',        ugettext_lazy('SECTOR_GROUP_Chemical Sector')),
-    ('commercial',      ugettext_lazy('SECTOR_GROUP_Commercial Facilities Sector')),
-    ('communication',   ugettext_lazy('SECTOR_GROUP_Communications Sector')),
-    ('critical',        ugettext_lazy('SECTOR_GROUP_Critical Manufacturing Sector')),
-    ('dams',            ugettext_lazy('SECTOR_GROUP_Dams Sector')),
-    ('defense',         ugettext_lazy('SECTOR_GROUP_Defense Industrial Base Sector')),
-    ('emergency',       ugettext_lazy('SECTOR_GROUP_Emergency Services Sector')),
-    ('energy',          ugettext_lazy('SECTOR_GROUP_Energy Sector')),
-    ('financial',       ugettext_lazy('SECTOR_GROUP_Financial Services Sector')),
-    ('food',            ugettext_lazy('SECTOR_GROUP_Food and Agriculture Sector')),
-    ('government',      ugettext_lazy('SECTOR_GROUP_Government Facilities Sector')),
-    ('healthcare',      ugettext_lazy('SECTOR_GROUP_Healthcare and Public Health Sector')),
-    ('information',     ugettext_lazy('SECTOR_GROUP_Information Technology Sector')),
-    ('nuclear',         ugettext_lazy('SECTOR_GROUP_Nuclear Reactors, Materials, and Waste Sector')),
-    ('other',           ugettext_lazy('SECTOR_GROUP_Other')),
-    ('transport',       ugettext_lazy('SECTOR_GROUP_Transportation Systems Sector')),
-    ('water',           ugettext_lazy('SECTOR_GROUP_Water and Wastewater Systems Sector')),
+SECTOR_GROUP_CHOICES = (
+    ('chemical', ugettext_lazy('SECTOR_GROUP_Chemical Sector')),
+    ('commercial', ugettext_lazy('SECTOR_GROUP_Commercial Facilities Sector')),
+    ('communication', ugettext_lazy('SECTOR_GROUP_Communications Sector')),
+    ('critical', ugettext_lazy('SECTOR_GROUP_Critical Manufacturing Sector')),
+    ('dams', ugettext_lazy('SECTOR_GROUP_Dams Sector')),
+    ('defense', ugettext_lazy('SECTOR_GROUP_Defense Industrial Base Sector')),
+    ('emergency', ugettext_lazy('SECTOR_GROUP_Emergency Services Sector')),
+    ('energy', ugettext_lazy('SECTOR_GROUP_Energy Sector')),
+    ('financial', ugettext_lazy('SECTOR_GROUP_Financial Services Sector')),
+    ('food', ugettext_lazy('SECTOR_GROUP_Food and Agriculture Sector')),
+    ('government', ugettext_lazy('SECTOR_GROUP_Government Facilities Sector')),
+    ('healthcare', ugettext_lazy('SECTOR_GROUP_Healthcare and Public Health Sector')),
+    ('information', ugettext_lazy('SECTOR_GROUP_Information Technology Sector')),
+    ('nuclear', ugettext_lazy('SECTOR_GROUP_Nuclear Reactors, Materials, and Waste Sector')),
+    ('other', ugettext_lazy('SECTOR_GROUP_Other')),
+    ('transport', ugettext_lazy('SECTOR_GROUP_Transportation Systems Sector')),
+    ('water', ugettext_lazy('SECTOR_GROUP_Water and Wastewater Systems Sector')),
 )
 
-#CRITICAL_INFRASTRUCTURE
-CRITICAL_INFRASTRUCTURE_CHOICES=  (
-    ('Information and Communication Services',                                      ugettext_lazy('CI_Information and Communication Services')),
-    ('Financial Services',                                                          ugettext_lazy('CI_Financial Services')),
-    ('Aviation Services',                                                           ugettext_lazy('CI_Aviation Services')),
-    ('Railway Services',                                                            ugettext_lazy('CI_Railway Services')),
-    ('Electric Power Supply Services',                                              ugettext_lazy('CI_Electric Power Supply Services')),
-    ('Gas Supply Services',                                                         ugettext_lazy('CI_Gas Supply Services')),
-    ('Government and Administrative Services (Including Municipal Government)',     ugettext_lazy('CI_Government and Administrative Services (Including Municipal Government)')),
-    ('Medical Services',                                                            ugettext_lazy('CI_Medical Services')),
-    ('Water Services',                                                              ugettext_lazy('CI_Water Services')),
-    ('Logistics Services',                                                          ugettext_lazy('CI_Logistics Services')),
-    ('Chemical Industries',                                                         ugettext_lazy('CI_Chemical Industries')),
-    ('Credit Card Services',                                                        ugettext_lazy('CI_Credit Card Services')),
-    ('Petroleum Industries',                                                        ugettext_lazy('CI_Petroleum Industries')),
-    ('Other',                                                                       ugettext_lazy('CI_Other')),
+# CRITICAL_INFRASTRUCTURE
+CRITICAL_INFRASTRUCTURE_CHOICES = (
+    ('Information and Communication Services', ugettext_lazy('CI_Information and Communication Services')),
+    ('Financial Services', ugettext_lazy('CI_Financial Services')),
+    ('Aviation Services', ugettext_lazy('CI_Aviation Services')),
+    ('Railway Services', ugettext_lazy('CI_Railway Services')),
+    ('Electric Power Supply Services', ugettext_lazy('CI_Electric Power Supply Services')),
+    ('Gas Supply Services', ugettext_lazy('CI_Gas Supply Services')),
+    ('Government and Administrative Services (Including Municipal Government)', ugettext_lazy('CI_Government and Administrative Services (Including Municipal Government)')),
+    ('Medical Services', ugettext_lazy('CI_Medical Services')),
+    ('Water Services', ugettext_lazy('CI_Water Services')),
+    ('Logistics Services', ugettext_lazy('CI_Logistics Services')),
+    ('Chemical Industries', ugettext_lazy('CI_Chemical Industries')),
+    ('Credit Card Services', ugettext_lazy('CI_Credit Card Services')),
+    ('Petroleum Industries', ugettext_lazy('CI_Petroleum Industries')),
+    ('Other', ugettext_lazy('CI_Other')),
 )
 
 SHARING_GROUP_CSC = 'csc'
@@ -102,7 +102,7 @@ SHARING_GROUP_CSC = 'csc'
 SHARING_RANGE_TYPE_KEY_ALL = 'all'
 SHARING_RANGE_TYPE_KEY_GROUP = 'group'
 SHARING_RANGE_TYPE_KEY_PEOPLE = 'people'
-SHARING_RANGE_CHOICES=(
+SHARING_RANGE_CHOICES = (
     (SHARING_RANGE_TYPE_KEY_ALL, 'With the CSC Community'),
     (SHARING_RANGE_TYPE_KEY_GROUP, 'With a group'),
     (SHARING_RANGE_TYPE_KEY_PEOPLE, 'With people'),

--- a/src/stip/common/stip_stix2.py
+++ b/src/stip/common/stip_stix2.py
@@ -1,21 +1,23 @@
 from stix2.v21.sdo import Identity
 
-#S-TIP オブジェクトに格納する固定値
+# S-TIP オブジェクトに格納する固定値
 STIP_IDENTITY_CLASS = 'organization'
 STIP_NAME = 'Fujitsu System Integration Laboratories.'
 
-#S-TIP の Identity を作成する
+# S-TIP の Identity を作成する
+
+
 def _get_stip_identname(stip_user=None):
-    #identity の name は stip_user の affiliation から
+    # identity の name は stip_user の affiliation から
     try:
         name = stip_user.affiliation
         if len(name) == 0:
             name = STIP_NAME
-    except:
-        #affiliation が取れないもしくは空文字列の場合はデフォルト
+    except BaseException:
+        # affiliation が取れないもしくは空文字列の場合はデフォルト
         name = STIP_NAME
 
     stip_identity = Identity(
         identity_class=STIP_IDENTITY_CLASS,
-        name = name)
+        name=name)
     return stip_identity

--- a/src/stip/common/stip_stix2.py
+++ b/src/stip/common/stip_stix2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from stix2.v21.sdo import Identity
 
 #S-TIP オブジェクトに格納する固定値

--- a/src/stip/common/stip_stix2.py
+++ b/src/stip/common/stip_stix2.py
@@ -4,9 +4,8 @@ from stix2.v21.sdo import Identity
 STIP_IDENTITY_CLASS = 'organization'
 STIP_NAME = 'Fujitsu System Integration Laboratories.'
 
+
 # S-TIP の Identity を作成する
-
-
 def _get_stip_identname(stip_user=None):
     # identity の name は stip_user の affiliation から
     try:

--- a/src/stip/common/tld.py
+++ b/src/stip/common/tld.py
@@ -10,7 +10,7 @@ class TLD(object):
             return
         try:
             tld_dict = {}
-            f = codecs.open(file_path, 'r', 'utf-8')
+            f = codecs.open(file_path, 'r', encoding='utf-8')
             lines = f.readlines()
             f.close()
             for line in lines:

--- a/src/stip/common/tld.py
+++ b/src/stip/common/tld.py
@@ -1,21 +1,22 @@
 import codecs
 
+
 class TLD(object):
     tld_dict_ = None
 
-    #TLD(Top Level Domain)リストを読み込む
-    def __init__(self,file_path):
+    # TLD(Top Level Domain)リストを読み込む
+    def __init__(self, file_path):
         if TLD.tld_dict_ is not None:
-            return 
+            return
         try:
             tld_dict = {}
-            f = codecs.open(file_path,  'r', 'utf-8')
+            f = codecs.open(file_path, 'r', 'utf-8')
             lines = f.readlines()
             f.close()
             for line in lines:
-                #空行、コメント行以外をリストに追加
-                if line[:-1] !='' and not line.startswith('//') :
-                    tld_dict.update({line[:-1]:''})
+                # 空行、コメント行以外をリストに追加
+                if line[:-1] != '' and not line.startswith('//'):
+                    tld_dict.update({line[:-1]: ''})
 
             self.set_dict(tld_dict)
         except Exception as e:
@@ -27,9 +28,9 @@ class TLD(object):
 
     def set_dict(self, param):
         TLD.tld_dict_ = param
-        
-    def get_tld(self,domain_name):
-        #要素数が長い方をTLDとして採用する
+
+    def get_tld(self, domain_name):
+        # 要素数が長い方をTLDとして採用する
         tld = None
         if domain_name is None:
             return None
@@ -39,15 +40,15 @@ class TLD(object):
                 tld = '.'.join(klist[i:])
                 break
         return tld
-    
-    def split_domain(self,domain_name):
-        #TLDを取得し、TLDを構成する文字列数をカウント
+
+    def split_domain(self, domain_name):
+        # TLDを取得し、TLDを構成する文字列数をカウント
         _tld = self.get_tld(domain_name)
         if _tld is None:
-            return (domain_name,None)
+            return (domain_name, None)
         tld_word_num = len(_tld.split('.'))
-        #domain名からTLD分の要素を省いた文字列を取得
+        # domain名からTLD分の要素を省いた文字列を取得
         domain_list = domain_name.split('.')
         split_domain = '.'.join(domain_list[:tld_word_num * -1])
-        #分割した文字列を tuple にして返却
-        return (split_domain,_tld)
+        # 分割した文字列を tuple にして返却
+        return (split_domain, _tld)

--- a/src/stip/common/tld.py
+++ b/src/stip/common/tld.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import codecs
 
 class TLD(object):
@@ -20,7 +19,7 @@ class TLD(object):
 
             self.set_dict(tld_dict)
         except Exception as e:
-            print e
+            print(e)
             raise e
 
     def get_dict(self):


### PR DESCRIPTION
Python3に対応するsrcに修正
  - python2to3コマンドによるsrc変換
  - autopep8コマンドによるsrc変換+整形
  - open関数のencoding='utf-8'指定を追加
  - インストールモジュールのバージョン修正 