### PR TITLE
Update installation of matcher, slider and cybox

### DIFF
--- a/install_scripts/requirements_rs.txt
+++ b/install_scripts/requirements_rs.txt
@@ -11,7 +11,7 @@ stix2>=1.4.0
 libtaxii
 mysqlclient
 stix2-patterns>=1.3.0
-stix2-slider
+stix2-slider>=3.0.0
 python-decouple
 pymongo>=3.10.1
 bleach
@@ -20,4 +20,5 @@ Unipath
 slackclient
 maec
 misp_stix_converter
-cybox==2.1.0.20
+cybox>=2.1.0.21
+stix2-matcher>=1.0.0

--- a/setup_rs.sh
+++ b/setup_rs.sh
@@ -28,13 +28,6 @@ apt install -y mysql-server libmysqlclient-dev libssl-dev
 ## pip install
 pip3 install -r $SCRIPTS_DIR/requirements_rs.txt
 
-# install cti-pattern-matcher from github
-git clone https://github.com/oasis-open/cti-pattern-matcher.git
-cd cti-pattern-matcher/
-python3 setup.py install
-cd -
-chown -R stip:stip cti-pattern-matcher
-
 # copy RS setting
 mkdir -p $INSTALL_DIR/rs/bin
 mkdir -p $INSTALL_DIR/rs/community


### PR DESCRIPTION
I will update installation script with the following changes:
* cti-pattern-matcher  
  - Change setup.py install to pip (stix2-matcher in Pypi)
* stix2-slider/cybox
  - stix2-slider 3.0 works with latest version of cybox (2.1.0.21).