### PR TITLE
Fixed to an issue about login

### DIFF
--- a/src/stip/common/login.py
+++ b/src/stip/common/login.py
@@ -11,7 +11,7 @@ def _get_login_authcode(request):
     return get_text_field_value(request, 'authcode', default_value='')
 
 
-def login(request, redirect_to):
+def login(request, redirect_to, password_modified_to='password_modified'):
     if request.user.is_authenticated():
         return redirect(redirect_to)
 
@@ -22,10 +22,10 @@ def login(request, redirect_to):
     if user:
         request.session['username'] = str(user)
         if user.totp_secret is None:
-            if not user.is_modified_password:
-                return redirect('password_modified')
             auth_login(request, user)
             request = set_language_setting(request, user)
+            if not user.is_modified_password:
+                return redirect(password_modified_to)
             return redirect(redirect_to)
         else:
             return render(request, 'cover_totp.html')

--- a/src/stip/common/login.py
+++ b/src/stip/common/login.py
@@ -34,7 +34,7 @@ def login(request, redirect_to, password_modified_to='password_modified'):
         return render(request, 'cover.html', replace_dict)
 
 
-def login_totp(request, redirect_to):
+def login_totp(request, redirect_to, password_modified_to='password_modified'):
     if request.user.is_authenticated():
         return redirect(redirect_to)
 
@@ -47,6 +47,8 @@ def login_totp(request, redirect_to):
     if totp.verify(authcode):
         auth_login(request, user)
         request = set_language_setting(request, user)
+        if not user.is_modified_password:
+            return redirect(password_modified_to)
         return redirect(redirect_to)
     else:
         replace_dict['error_msg'] = 'Two-factor authentication failed.'


### PR DESCRIPTION
I fixed about an user login.
When an user is created and his/her password must be changed.
However he/she attempt to login, he cannot login.
When S-TIP redirect to a password modified page, he/she is not authorized.
I fixed to authorized  the user before redirect to the page.
I also fixed to be able to specify to add password modify alias.

---

ユーザーログイン関連を修正しました。
新しくユーザが作られた時、そのユーザはパスワードを変更しないといけませんでした。
しかし、その状態でそのユーザはログインできません。
というのは、S-TIP がパスワード変更ページに redirect する前に authorized していなかったからです。
なので、遷移先のページでログインになっていない -> ログインページというループになっていました。
なので、今回、パスワード変更ページに redirect する前に authorized する修正をしました。
また、これを気にパスワード変更ページ alias を指定可能にしました。

