### PR TITLE
Remove stix-matcher build from Dockerfile and remove stix2-slider (duplicate defined)

### DIFF
--- a/docker/stip/Dockerfile
+++ b/docker/stip/Dockerfile
@@ -33,10 +33,6 @@ RUN ln -s ${COMMON_DIR}/src ${INSTALL_DIR}/common/src && ln -s ${COMMON_DIR}/img
 
 # stip-rs setup
 WORKDIR /stip-common
-RUN git clone https://github.com/oasis-open/cti-pattern-matcher.git
-WORKDIR /stip-common/cti-pattern-matcher/
-RUN python3 setup.py install
-WORKDIR /stip-common
 RUN git clone https://github.com/s-tip/stip-rs.git
 RUN mkdir -p ${INSTALL_DIR}/rs/bin ${INSTALL_DIR}/rs/community ${INSTALL_DIR}/rs/data ${INSTALL_DIR}/rs/staticfiles
 RUN ln -s ${COMMON_DIR}/stip-rs/src ${INSTALL_DIR}/rs/src

--- a/install_scripts/requirements_rs.txt
+++ b/install_scripts/requirements_rs.txt
@@ -23,4 +23,5 @@ maec
 misp_stix_converter
 cybox>=2.1.0.21
 pyotp
+stix2-matcher>=1.0.0
 

--- a/install_scripts/requirements_sns.txt
+++ b/install_scripts/requirements_sns.txt
@@ -5,7 +5,6 @@ pdfminer.six
 pillow
 stix-validator
 pymongo>=3.10.1
-stix2-slider
 reportlab
 jira
 taxii2-client>=2.0.0


### PR DESCRIPTION
- Remove stix-matcher build from Dockerfile (Move to requirements_rs.txt)
- Remove stix2-slider from requirement_sns.txt (Already exist in requirement_rs.txt)
