### PR TITLE
Fix error about six.moves.collection_abc

### DIFF
--- a/install_scripts/requirements_rs.txt
+++ b/install_scripts/requirements_rs.txt
@@ -7,8 +7,8 @@ IPy
 stix>=1.2.0.10
 stix2-elevator>=2.1.1
 stix2-validator==2.0.0.dev1
-stix2>=1.4.0
 six>=1.15.0
+stix2>=1.15.0
 libtaxii
 mysqlclient
 stix2-patterns>=1.3.0


### PR DESCRIPTION
The old version of six causes following error: 
```
ModuleNotFoundError: No module named 'six.moves.collections_abc'
```
Installing new version of stix2 upgrades six (>=1.13.0), then the error was solved.