### PR TITLE
Fixed an issue about txs setup

### DIFF
--- a/setup_txs.sh
+++ b/setup_txs.sh
@@ -11,10 +11,11 @@ chown -R stip:stip stip-txs
 apt install -y gunicorn3
 
 ## pip install
-pip3 install supervisor>=4.1.0
+pip3 install 'supervisor>=4.1.0'
 pip3 install 'gunicorn>=19.10,<20.0'
 pip3 install libtaxii
 pip3 install opentaxii==0.1.7
+pip3 install anyconfig==0.9.10
 
 # copy TXS setting
 mkdir -p $INSTALL_DIR/txs


### PR DESCRIPTION
I found some issues when I set up stip-txs.

- At `pip3 install supervisor>=4.1.0` in `setup_txs.sh`, this command will output `=4.1.0` file
- `opentaxii` library goes wrong when it uses the latest `anyconfig` library.
