### PR TITLE
Fixed an issue about SSO

### DIFF
--- a/install_scripts/env
+++ b/install_scripts/env
@@ -5,3 +5,12 @@ MYSQL_PASSWORD=stip
 MYSQL_DBNAME=s_tip
 TIME_ZONE=UTC
 
+# If you would like to switch a application by sub domain name instead of port, set domain name with a leading period.
+# Example:
+# If you would like to set domain name below,
+# RS: rs.s-tip.domain.net
+# SNS: sns.s-tip.domain.net
+# GV: gv.s-tip.domain.net
+# you have to set '.s-tip.domain.net' to COOKIE_DOMAIN_NAME.
+#COOKIE_DOMAIN_NAME=.s-tip.domain.net
+


### PR DESCRIPTION
I fixed an issue (#84 ) about SSO.
I add a setting item in env sample.

```
# If you would like to switch a application by sub domain name instead of port, set domain name with a leading period.
# Example:
# If you would like to set domain name below,
# RS: rs.s-tip.domain.net
# SNS: sns.s-tip.domain.net
# GV: gv.s-tip.domain.net
# you have to set '.s-tip.domain.net' to COOKIE_DOMAIN_NAME.
#COOKIE_DOMAIN_NAME=.s-tip.domain.net
```

When S-TIP is switched by port, you do not have to set `COOKIE_DOMAIN_NAME` .