### PR TITLE
Authenticate by APIKey

### DIFF
--- a/src/stip/common/rest_api_auth.py
+++ b/src/stip/common/rest_api_auth.py
@@ -1,0 +1,13 @@
+def auth_by_api_key(username, api_key):
+    if ((username is None) or (api_key is None)):
+        return None
+    try:
+        from ctirs.models.rs.models import STIPUser
+        user_doc = STIPUser.objects.get(username=username)
+    except Exception:
+        return None
+    if user_doc is None:
+        return None
+    if user_doc.api_key != api_key:
+        return None
+    return user_doc


### PR DESCRIPTION
Issue about s-tip/stip-common#89 .
In case of TAXII 1.1 server and TAXII 2.1 server, I fixed to authenticate users by API Key instead of Web Interface credential.

