### PR TITLE
The latest stix2 library support

### DIFF
--- a/install_scripts/requirements_rs.txt
+++ b/install_scripts/requirements_rs.txt
@@ -5,13 +5,13 @@ apscheduler
 requests
 IPy
 stix>=1.2.0.10
-stix2-elevator>=2.1.1
-stix2-validator==2.0.0.dev1
-stix2>=1.4.0
+stix2-elevator>=4.0.1
+stix2-validator>=3.0.0
+stix2>=3.0.0
 six>=1.15.0
 libtaxii
 mysqlclient
-stix2-patterns>=1.3.0
+stix2-patterns>=1.3.2
 stix2-slider>=3.0.0
 python-decouple
 pymongo>=3.10.1


### PR DESCRIPTION
Issue about #97 .

STIX2 library released major version (version 3.0.0)
I installed the latest stix2 library and confirmed the function.


