### PR TITLE
Modified required slack library name

### DIFF
--- a/install_scripts/requirements_rs.txt
+++ b/install_scripts/requirements_rs.txt
@@ -18,7 +18,7 @@ pymongo>=3.10.1
 bleach
 pymisp<2.4.161
 Unipath
-slackclient>=2.9.3
+slack-sdk
 maec
 misp_stix_converter
 cybox>=2.1.0.21

--- a/install_scripts/requirements_rs.txt
+++ b/install_scripts/requirements_rs.txt
@@ -16,7 +16,7 @@ stix2-slider>=3.0.0
 python-decouple
 pymongo>=3.10.1
 bleach
-pymisp<2.4.161
+pymisp>=2.4.161
 Unipath
 slack-sdk
 maec


### PR DESCRIPTION
Fixed the slack library name in `requirements_rs.txt` because `slack_client` will be deprecated by the end of September 2022