### PR TITLE
Add the aiohttp into the requirements.txt

### DIFF
--- a/install_scripts/requirements_sns.txt
+++ b/install_scripts/requirements_sns.txt
@@ -12,5 +12,6 @@ iocextract
 beautifulsoup4
 splunk-sdk
 nest-asyncio
+aiohttp
 qrcode
 


### PR DESCRIPTION
Add the `aiohttp` library into `requrements_sns.txt`, because this library is not installed by default under python 3.10.